### PR TITLE
Python3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,6 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+.ropeproject/
 
 .idea/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests>=2.2.1
+future>=0.14.3

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,11 +1,5 @@
 __author__ = 'fermayo'
 
-try:
-    import configparser
-except ImportError:
-    import sys
-    sys.modules['configparser'] = __import__('ConfigParser')
-
 # Python 3.4.2 includes mock in-box, prefer that version
 # For other versions, patch it up to use the external mock library
 try:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,18 @@
 __author__ = 'fermayo'
+
+try:
+    import configparser
+except ImportError:
+    import sys
+    sys.modules['configparser'] = __import__('ConfigParser')
+
+# Python 3.4.2 includes mock in-box, prefer that version
+# For other versions, patch it up to use the external mock library
+try:
+    from unittest import mock
+except ImportError:
+    import sys
+    sys.modules['unittest'] = __import__('unittest')
+    sys.modules['unittest.mock'] = __import__('mock')
+    setattr(sys.modules['unittest'], 'mock', __import__('mock'))
+

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+import unittest.mock as mock
 
 import tutum
 from .fake_api import *

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -3,7 +3,7 @@ import unittest
 import mock
 
 import tutum
-from fake_api import *
+from .fake_api import *
 
 
 class ActionTestCase(unittest.TestCase):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -71,7 +71,7 @@ class AuthTestCase(unittest.TestCase):
         self.assertEqual(apikey_read, FAKE_APIKEY)
         os.remove(file.name)
 
-    @mock.patch.object(tutum.auth.ConfigParser.ConfigParser, 'read', side_effect=configparser.Error)
+    @mock.patch.object(tutum.auth.configparser.ConfigParser, 'read', side_effect=configparser.Error)
     def test_auth_load_from_file_with_exception(self, mock_read):
         user_read, apikey_read = tutum.auth.load_from_file('abc')
         self.assertIsNone(user_read)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -3,7 +3,7 @@ import tempfile
 import unittest
 import configparser
 
-import mock
+import unittest.mock as mock
 
 import tutum
 from .fake_api import *

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -63,7 +63,7 @@ class AuthTestCase(unittest.TestCase):
         self.assertIsNone(tutum.apikey)
 
     def test_auth_load_from_file(self):
-        file = tempfile.NamedTemporaryFile(delete=False)
+        file = tempfile.NamedTemporaryFile('w', delete=False)
         with file as f:
             f.writelines(["[auth]\n", "user = %s\n" % FAKE_USER, "apikey = %s\n" % FAKE_APIKEY])
         user_read, apikey_read = tutum.auth.load_from_file(file.name)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,12 +1,12 @@
 import os
 import tempfile
 import unittest
-import ConfigParser
+import configparser
 
 import mock
 
 import tutum
-from fake_api import *
+from .fake_api import *
 
 
 class AuthTestCase(unittest.TestCase):
@@ -71,7 +71,7 @@ class AuthTestCase(unittest.TestCase):
         self.assertEqual(apikey_read, FAKE_APIKEY)
         os.remove(file.name)
 
-    @mock.patch.object(tutum.auth.ConfigParser.ConfigParser, 'read', side_effect=ConfigParser.Error)
+    @mock.patch.object(tutum.auth.ConfigParser.ConfigParser, 'read', side_effect=configparser.Error)
     def test_auth_load_from_file_with_exception(self, mock_read):
         user_read, apikey_read = tutum.auth.load_from_file('abc')
         self.assertIsNone(user_read)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,7 +1,7 @@
 import unittest
 import json
 
-import mock
+import unittest.mock as mock
 
 import tutum
 from tutum.api.base import Restful, Mutable, Immutable

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+import unittest.mock as mock
 
 import tutum
 from .fake_api import *

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -3,7 +3,7 @@ import unittest
 import mock
 
 import tutum
-from fake_api import *
+from .fake_api import *
 
 
 class ContainerTestCase(unittest.TestCase):

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,11 +1,11 @@
 import unittest
-import urlparse
+import urllib.parse
 
 import mock
 import requests
 
 import tutum
-from fake_api import fake_resp
+from .fake_api import fake_resp
 from tutum.api.base import send_request
 
 
@@ -18,7 +18,7 @@ class SendRequestTestCase(unittest.TestCase):
         self.assertRaises(tutum.TutumApiError, send_request, 'METHOD', 'path', data='data')
         headers = {'Content-Type': 'application/json', 'User-Agent': 'python-tutum/v%s' % tutum.__version__}
         headers.update(tutum.auth.get_auth_header())
-        mock_Request.assert_called_with('METHOD', urlparse.urljoin(tutum.base_url, 'path/'),
+        mock_Request.assert_called_with('METHOD', urllib.parse.urljoin(tutum.base_url, 'path/'),
                                         headers=headers, data='data')
 
         mock_send.return_value = fake_resp(lambda: (200, json_obj))

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,7 +1,7 @@
 import unittest
 import urllib.parse
 
-import mock
+import unittest.mock as mock
 import requests
 
 import tutum

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -3,7 +3,7 @@ import unittest
 import mock
 
 import tutum
-from fake_api import *
+from .fake_api import *
 
 
 class ImageTestCase(unittest.TestCase):

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+import unittest.mock as mock
 
 import tutum
 from .fake_api import *

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+import unittest.mock as mock
 
 import tutum
 from .fake_api import *

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -3,7 +3,7 @@ import unittest
 import mock
 
 import tutum
-from fake_api import *
+from .fake_api import *
 
 
 class NodeTestCase(unittest.TestCase):

--- a/tests/test_nodecluster.py
+++ b/tests/test_nodecluster.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+import unittest.mock as mock
 
 import tutum
 from .fake_api import *

--- a/tests/test_nodecluster.py
+++ b/tests/test_nodecluster.py
@@ -3,7 +3,7 @@ import unittest
 import mock
 
 import tutum
-from fake_api import *
+from .fake_api import *
 
 
 class NodeClusterTestCase(unittest.TestCase):

--- a/tests/test_nodeprovider.py
+++ b/tests/test_nodeprovider.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+import unittest.mock as mock
 
 import tutum
 from .fake_api import *

--- a/tests/test_nodeprovider.py
+++ b/tests/test_nodeprovider.py
@@ -3,7 +3,7 @@ import unittest
 import mock
 
 import tutum
-from fake_api import *
+from .fake_api import *
 
 
 class ProviderTestCase(unittest.TestCase):

--- a/tests/test_noderegion.py
+++ b/tests/test_noderegion.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+import unittest.mock as mock
 
 import tutum
 from .fake_api import *

--- a/tests/test_noderegion.py
+++ b/tests/test_noderegion.py
@@ -3,7 +3,7 @@ import unittest
 import mock
 
 import tutum
-from fake_api import *
+from .fake_api import *
 
 
 class RegionTestCase(unittest.TestCase):

--- a/tests/test_nodetype.py
+++ b/tests/test_nodetype.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+import unittest.mock as mock
 
 import tutum
 from .fake_api import *

--- a/tests/test_nodetype.py
+++ b/tests/test_nodetype.py
@@ -3,7 +3,7 @@ import unittest
 import mock
 
 import tutum
-from fake_api import *
+from .fake_api import *
 
 
 class NodeTypeTestCase(unittest.TestCase):

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,6 +1,6 @@
 import unittest
 
-import mock
+import unittest.mock as mock
 
 import tutum
 from .fake_api import *

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -3,7 +3,7 @@ import unittest
 import mock
 
 import tutum
-from fake_api import *
+from .fake_api import *
 
 
 class ServiceTestCase(unittest.TestCase):

--- a/tutum/__init__.py
+++ b/tutum/__init__.py
@@ -1,6 +1,9 @@
 import logging
 import os
 
+from future.standard_library import install_aliases
+install_aliases()
+
 from tutum.api import auth
 from tutum.api.service import Service
 from tutum.api.container import Container

--- a/tutum/api/action.py
+++ b/tutum/api/action.py
@@ -1,4 +1,4 @@
-from base import Immutable
+from .base import Immutable
 
 
 class Action(Immutable):

--- a/tutum/api/auth.py
+++ b/tutum/api/auth.py
@@ -1,9 +1,9 @@
-import ConfigParser
+import configparser
 import os
 
 from requests.auth import HTTPBasicAuth
 import tutum
-from http import send_request
+from .http import send_request
 
 
 def authenticate(username, password):
@@ -67,10 +67,10 @@ def load_from_file(file="~/.tutum"):
     """
     try:
         cfgfile = os.path.expanduser(file)
-        cp = ConfigParser.ConfigParser()
+        cp = configparser.ConfigParser()
         cp.read(cfgfile)
         return cp.get("auth", "user"), cp.get("auth", "apikey")
-    except ConfigParser.Error:
+    except configparser.Error:
         return None, None
 
 

--- a/tutum/api/base.py
+++ b/tutum/api/base.py
@@ -1,7 +1,7 @@
 import json as json_parser
 
-from http import send_request
-from exceptions import TutumApiError
+from .http import send_request
+from .exceptions import TutumApiError
 
 
 class Restful(object):
@@ -9,7 +9,7 @@ class Restful(object):
 
     def __init__(self, **kwargs):
         """Simply reflect all the values in kwargs"""
-        for k, v in kwargs.items():
+        for k, v in list(kwargs.items()):
             setattr(self, k, v)
 
     def __setattr__(self, name, value):
@@ -35,7 +35,7 @@ class Restful(object):
         """Internal. Sets the model attributes to the dictionary values passed"""
         endpoint = getattr(self, 'endpoint', None)
         assert endpoint, "Endpoint not specified for %s" % self.__class__.__name__
-        for k, v in dict.items():
+        for k, v in list(dict.items()):
             setattr(self, k, v)
         self._detail_uri = "/".join([endpoint, self.pk])
         self.__setchanges__([])

--- a/tutum/api/container.py
+++ b/tutum/api/container.py
@@ -1,6 +1,6 @@
 import json
 
-from base import Mutable
+from .base import Mutable
 
 
 class Container(Mutable):

--- a/tutum/api/http.py
+++ b/tutum/api/http.py
@@ -1,8 +1,8 @@
-from urlparse import urljoin
+from urllib.parse import urljoin
 
 from requests import Request, Session
 import tutum
-from exceptions import TutumApiError, TutumAuthError
+from .exceptions import TutumApiError, TutumAuthError
 
 
 def send_request(method, path, **kwargs):

--- a/tutum/api/image.py
+++ b/tutum/api/image.py
@@ -1,4 +1,4 @@
-from base import Mutable, Taggable
+from .base import Mutable, Taggable
 
 
 class Image(Mutable, Taggable):

--- a/tutum/api/node.py
+++ b/tutum/api/node.py
@@ -1,4 +1,4 @@
-from base import Mutable, Taggable
+from .base import Mutable, Taggable
 
 
 class Node(Mutable, Taggable):

--- a/tutum/api/nodecluster.py
+++ b/tutum/api/nodecluster.py
@@ -1,4 +1,4 @@
-from base import Mutable, Taggable
+from .base import Mutable, Taggable
 from tutum.api.nodetype import NodeType
 from tutum.api.noderegion import Region
 
@@ -18,7 +18,7 @@ class NodeCluster(Mutable, Taggable):
 
     @classmethod
     def create(cls, **kwargs):
-        for key, value in kwargs.iteritems():
+        for key, value in kwargs.items():
             if key == "node_type" and isinstance(value, NodeType):
                 kwargs[key] = getattr(value, "resource_uri", "")
             if key == "region" and isinstance(value, Region):

--- a/tutum/api/nodeprovider.py
+++ b/tutum/api/nodeprovider.py
@@ -1,4 +1,4 @@
-from base import Immutable
+from .base import Immutable
 
 
 class Provider(Immutable):

--- a/tutum/api/noderegion.py
+++ b/tutum/api/noderegion.py
@@ -1,4 +1,4 @@
-from base import Immutable
+from .base import Immutable
 
 
 class Region(Immutable):

--- a/tutum/api/nodetype.py
+++ b/tutum/api/nodetype.py
@@ -1,4 +1,4 @@
-from base import Immutable
+from .base import Immutable
 
 
 class NodeType(Immutable):

--- a/tutum/api/service.py
+++ b/tutum/api/service.py
@@ -1,6 +1,6 @@
 import json
 
-from base import Mutable, Taggable, Webhookable
+from .base import Mutable, Taggable, Webhookable
 
 
 class Service(Mutable, Taggable, Webhookable):

--- a/tutum/api/tag.py
+++ b/tutum/api/tag.py
@@ -1,8 +1,8 @@
 import json as json_parser
 
-from base import Taggable
-from http import send_request
-from exceptions import TutumApiError
+from .base import Taggable
+from .http import send_request
+from .exceptions import TutumApiError
 
 
 class Tag(object):

--- a/tutum/api/webhookhandler.py
+++ b/tutum/api/webhookhandler.py
@@ -1,8 +1,8 @@
 import json as json_parser
 
-from base import Webhookable
-from http import send_request
-from exceptions import TutumApiError
+from .base import Webhookable
+from .http import send_request
+from .exceptions import TutumApiError
 
 
 class WebhookHandler(object):


### PR DESCRIPTION
This modifies the codebase in the most automatic way to support python2 and python3.
The code was made compatible by:
1) running 2to3 over the codebase
2) Fixing up small bugs in python3 related to file encoding
3) using the builtin unittest.mock library for testing

and then ensuring python2.7 compatibility by using future.standard_library.install_aliases() and making a custom fix for unittest.mock

I have verified that the unittests pass in both python 2.7.9 and python 3.4.2.

A possible future todo would be to use absolute imports instead of relative imports as the 2to3 tool has done, but that's partially a coding guidelines thing.