### PR TITLE
in readme, web_public_dns to public_dns

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,7 +96,7 @@ Containers
     [<tutum.api.container.Container object at 0x10701ca90>, <tutum.api.container.Container object at 0x10701ca91>]
     >>> container = tutum.Container.fetch("7d6696b7-fbaf-471d-8e6b-ce7052586c24")
     <tutum.api.container.Container object at 0x10701ca90>
-    >>> container.web_public_dns = "my-web-app.example.com"
+    >>> container.public_dns = "my-web-app.example.com"
     >>> container.save()
     True
     >>> container.stop()


### PR DESCRIPTION
attribute `web_public_dns` exist?

```python
In [172]: container.public_dns
Out[172]: u'my-new-app-1.juanpabloaj.cont.tutum.io'

In [173]: container.web_public_dns
AttributeError: 'Container' object has no attribute 'web_public_dns'
'Container' object has no attribute 'web_public_dns'
```