### PR TITLE
Fix support for Python 3 and add CI testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,4 +11,3 @@ prepare:clean
 
 test:prepare
 	venv/bin/python setup.py test
-

--- a/circle.yml
+++ b/circle.yml
@@ -1,5 +1,5 @@
 test:
-  pre:
-    - pyenv global 2.6.8 3.4.0
   override:
-    - make test
+    - pyenv global 2.7.10 3.4.3
+    - $(pyenv which pip) install tox
+    - $(pyenv which tox)

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import unittest
 
 import unittest.mock as mock

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import os
 import tempfile
 import unittest

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import unittest
 import json
 

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import unittest
 
 import unittest.mock as mock

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import unittest
 
 import requests

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import unittest
 
 import unittest.mock as mock

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import unittest
 
 import unittest.mock as mock

--- a/tests/test_nodecluster.py
+++ b/tests/test_nodecluster.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import unittest
 
 import unittest.mock as mock

--- a/tests/test_nodeprovider.py
+++ b/tests/test_nodeprovider.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import unittest
 
 import unittest.mock as mock

--- a/tests/test_noderegion.py
+++ b/tests/test_noderegion.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import unittest
 
 import unittest.mock as mock

--- a/tests/test_nodetype.py
+++ b/tests/test_nodetype.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import unittest
 
 import unittest.mock as mock

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import unittest
 
 import unittest.mock as mock

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,11 @@
 [tox]
-envlist = py27
+envlist = py{27,34}
 
 [testenv]
+basepython =
+    py27: python2.7
+    py34: python3.4
 commands = {envpython} setup.py test
-deps = -rrequirements.txt
+deps =
+    -rrequirements.txt
+    py27: mock

--- a/tutum/api/action.py
+++ b/tutum/api/action.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from .base import Immutable, StreamingLog
 
 

--- a/tutum/api/auth.py
+++ b/tutum/api/auth.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import os
 
 import configparser

--- a/tutum/api/base.py
+++ b/tutum/api/base.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import json as json_parser
 import urllib
 import logging

--- a/tutum/api/base.py
+++ b/tutum/api/base.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 import json as json_parser
 import urllib
 import logging
@@ -331,7 +331,7 @@ class StreamingLog(StreamingAPI):
 
     @staticmethod
     def default_log_handler(message):
-        print message
+        print(message)
 
     def run_forever(self, *args, **kwargs):
         ws = websocket.WebSocketApp(self.url, header=self.header,

--- a/tutum/api/container.py
+++ b/tutum/api/container.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import json
 
 from .base import Mutable, StreamingLog

--- a/tutum/api/events.py
+++ b/tutum/api/events.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import urllib
 import json
 

--- a/tutum/api/http.py
+++ b/tutum/api/http.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from requests import Request, Session
 from requests import utils
 

--- a/tutum/api/image.py
+++ b/tutum/api/image.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from .base import Mutable, Taggable
 
 

--- a/tutum/api/imagetag.py
+++ b/tutum/api/imagetag.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from .exceptions import TutumApiError
 from .http import send_request
 import tutum

--- a/tutum/api/node.py
+++ b/tutum/api/node.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from .base import Mutable, Taggable
 
 

--- a/tutum/api/nodeaz.py
+++ b/tutum/api/nodeaz.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from .base import Immutable
 
 

--- a/tutum/api/nodecluster.py
+++ b/tutum/api/nodecluster.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from .base import Mutable, Taggable
 from tutum.api.nodetype import NodeType
 from tutum.api.noderegion import Region

--- a/tutum/api/nodeprovider.py
+++ b/tutum/api/nodeprovider.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from .base import Immutable
 
 

--- a/tutum/api/noderegion.py
+++ b/tutum/api/noderegion.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from .base import Immutable
 
 

--- a/tutum/api/nodetype.py
+++ b/tutum/api/nodetype.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from .base import Immutable
 
 

--- a/tutum/api/service.py
+++ b/tutum/api/service.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from .base import Mutable, Taggable, Triggerable, StreamingLog
 
 

--- a/tutum/api/stack.py
+++ b/tutum/api/stack.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from .base import Mutable
 from .exceptions import TutumApiError
-from http import send_request
+from .http import send_request
 
 
 class Stack(Mutable):

--- a/tutum/api/stack.py
+++ b/tutum/api/stack.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from .base import Mutable
 from .exceptions import TutumApiError
 from http import send_request

--- a/tutum/api/tag.py
+++ b/tutum/api/tag.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from .base import Taggable
 from .exceptions import TutumApiError
 

--- a/tutum/api/utils.py
+++ b/tutum/api/utils.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import re
 
 from .exceptions import TutumApiError, ObjectNotFound, NonUniqueIdentifier

--- a/tutum/api/volume.py
+++ b/tutum/api/volume.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from .base import Immutable
 
 

--- a/tutum/api/volumegroup.py
+++ b/tutum/api/volumegroup.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from .base import Immutable
 
 


### PR DESCRIPTION
First of all thanks for a great CLI, it's been a great pleasure to work with so far :+1:. 

I've just started moving a new project over to tutum that is running on Python 3 and realised that the `tutum` CLI wouldn't work on it. This PR contains the following fixes:
* Fixing a print statement with Python 2 syntax.
* Fix for a relative import without `.` which only works in Python 2.
* Adds the `from __future__ import absolute_imports` to ensure that relative imports behave the same in Python 2 and 3. 

I've also updated the tox configuration in the `tox.ini` so that it is possible to test against both versions (assuming both are installed on the system). I also updated the `circle.yml` configuration so that it runs the tox tests against Python 2.7.10 and 3.4.2. The way Circle CI is setup tox has to be run outside the system venv to ensure that the pyenv and system venv versions aren't conflicting. As a result, the commands in `circle.yml` need to retrieve the correct pyenv version of tox to run.

Please let me know what you think about this and if there's anything you'd like me to do to get this merged. I'm happy to adjust the PR accordingly.